### PR TITLE
create ice cream boss rage phase & launch-able pucks + clean up player movement

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,14 @@ config/icon="res://icon.svg"
 window/size/viewport_width=720
 window/size/viewport_height=1280
 
+[input]
+
+shoot_puck={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+
 [layer_names]
 
 2d_physics/layer_1="Environment"

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://c1jhp8cwiqypt" path="res://scenes/IceCube.tscn" id="2_cm0pq"]
 [ext_resource type="PackedScene" uid="uid://c56tdwek10dmn" path="res://scenes/Ball.tscn" id="3_r0du0"]
 [ext_resource type="PackedScene" uid="uid://cbbvng4r76oex" path="res://scenes/ice_cream_boss.tscn" id="4_rarhs"]
-[ext_resource type="PackedScene" uid="uid://bsdi5day054n2" path="res://scenes/HealthUI.tscn" id="5_healthui"]
+[ext_resource type="PackedScene" uid="uid://bsdi5day054n2" uid="uid://bsdi5day054n2" path="res://scenes/HealthUI.tscn" id="5_healthui"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_uu6xs"]
 friction = 0.0

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=10 format=3 uid="uid://b7mu1034wh12b"]
+[gd_scene load_steps=11 format=3 uid="uid://b7mu1034wh12b"]
 
 [ext_resource type="Script" uid="uid://c42nmw6pvf0vi" path="res://scripts/player.gd" id="1_xhfnw"]
 [ext_resource type="Script" uid="uid://qeipi7vrr5j6" path="res://scripts/stick.gd" id="2_kpjcp"]
 [ext_resource type="Texture2D" uid="uid://cgh1cok0km66j" path="res://assets/freezer/helmet.png" id="2_mdl7e"]
+[ext_resource type="PackedScene" uid="uid://btm58sgvpcslt" path="res://scenes/puck.tscn" id="2_qu4a1"]
 [ext_resource type="Texture2D" uid="uid://cr106ydl1b4j0" path="res://assets/ui/stick.png" id="3_3li8b"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_xhfnw"]
@@ -24,6 +25,7 @@ radius = 55.0364
 collision_layer = 2
 collision_mask = 0
 script = ExtResource("1_xhfnw")
+puck_scene = ExtResource("2_qu4a1")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_xhfnw")

--- a/scenes/ice_cream_boss.tscn
+++ b/scenes/ice_cream_boss.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://cbbvng4r76oex"]
+[gd_scene load_steps=7 format=3 uid="uid://drb605l5hvpfw"]
 
 [ext_resource type="Texture2D" uid="uid://by8xod6wb7ohy" path="res://assets/sprites/ice cream.png" id="1_51paf"]
 [ext_resource type="Script" uid="uid://bh2kvdma1guj7" path="res://scripts/ice_cream_boss.gd" id="1_q3t3g"]
-[ext_resource type="PackedScene" uid="uid://chkrln0i73kui" path="res://scenes/projectile_ice_cube.tscn" id="2_1hgda"]
-[ext_resource type="PackedScene" uid="uid://cevktclg1pfkk" path="res://scenes/IceCreamScoop.tscn" id="3_xrgnj"]
-[ext_resource type="PackedScene" uid="uid://cbb2ytbvuoo7c" path="res://scenes/Icicle.tscn" id="4_rmwav"]
+[ext_resource type="PackedScene" uid="uid://chkrln0i73kui" path="res://scenes/projectile_ice_cube.tscn" id="2_rmwav"]
+[ext_resource type="PackedScene" uid="uid://cevktclg1pfkk" path="res://scenes/IceCreamScoop.tscn" id="3_jfhmo"]
+[ext_resource type="PackedScene" uid="uid://cbb2ytbvuoo7c" path="res://scenes/Icicle.tscn" id="4_yuhxq"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_1vifr"]
 size = Vector2(419, 293)
@@ -13,9 +13,9 @@ size = Vector2(419, 293)
 collision_layer = 4
 collision_mask = 0
 script = ExtResource("1_q3t3g")
-projectile_ice_cube_scene = ExtResource("2_1hgda")
-projectile_ice_cream_scoop = ExtResource("3_xrgnj")
-projectile_icicle = ExtResource("4_rmwav")
+projectile_ice_cube_scene = ExtResource("2_rmwav")
+projectile_ice_cream_scoop = ExtResource("3_jfhmo")
+projectile_icicle = ExtResource("4_yuhxq")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(7, -3)

--- a/scenes/projectile_ice_cube.tscn
+++ b/scenes/projectile_ice_cube.tscn
@@ -8,7 +8,7 @@ size = Vector2(92, 100)
 
 [node name="ProjectileIceCube" type="Area2D"]
 collision_layer = 8
-collision_mask = 6
+collision_mask = 14
 script = ExtResource("1_3bhuc")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]

--- a/scenes/puck.tscn
+++ b/scenes/puck.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://btm58sgvpcslt"]
+
+[ext_resource type="Script" uid="uid://bixsrfu72806w" path="res://scripts/puck.gd" id="1_c1wug"]
+[ext_resource type="Texture2D" uid="uid://dq6xg64qkei3v" path="res://assets/ui/puck.png" id="1_gj0yh"]
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_ctoid"]
+radius = 20.0
+height = 86.0
+
+[node name="Puck" type="Area2D"]
+collision_layer = 8
+collision_mask = 0
+script = ExtResource("1_c1wug")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.084375, 0.0775)
+texture = ExtResource("1_gj0yh")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+rotation = 1.5708
+shape = SubResource("CapsuleShape2D_ctoid")

--- a/scripts/ice_cream_boss.gd
+++ b/scripts/ice_cream_boss.gd
@@ -3,21 +3,21 @@ extends Area2D
 @export var projectile_ice_cube_scene: PackedScene
 @export var projectile_ice_cream_scoop: PackedScene
 @export var projectile_icicle: PackedScene
-@export var throw_speed: float = 400.0
+
+@export var throw_speed := 400.0
+@export var hits_to_ice_wall_rage := 3
 
 # randomness used for later
 var rng = RandomNumberGenerator.new()
 
 var player: Node2D
+var is_raging := false
 
 func _ready():
 	add_to_group("boss")
 	player = get_tree().get_current_scene().find_child("Player", true, false)
 	$Timer.timeout.connect(_on_Timer_timeout)
 	
-func take_damage():
-	print("Ice cream boss hurt!") 
-
 func _on_Timer_timeout():
 	if player:
 		rng.randomize()
@@ -27,12 +27,14 @@ func _on_Timer_timeout():
 		var direction
 
 		if random_number < 2:
+			# "throw" the ice cube / icicle projectiles at the player
 			if random_number == 0:
 				projectile = projectile_ice_cube_scene.instantiate()
 			else:
 				projectile = projectile_icicle.instantiate()
 			direction = (player.global_position - global_position).normalized()
 		else:
+			# "throw" the ice cream scoop at a random position
 			projectile = projectile_ice_cream_scoop.instantiate()
 			
 			# Pick a random x within screen width, y slightly below screen
@@ -43,4 +45,33 @@ func _on_Timer_timeout():
 
 		get_parent().add_child(projectile)
 		projectile.global_position = global_position
-		projectile.velocity = direction * throw_speed	
+		projectile.velocity = direction * throw_speed
+
+func take_damage(amount := 1):
+	hits_to_ice_wall_rage -= amount
+	if not is_raging and hits_to_ice_wall_rage == 0:
+		rage()
+	
+func rage():
+	is_raging = true
+	throw_ice_wall()
+	run_away()
+	if player:
+		player.enable_vertical_movement()
+		player.enable_puck_shooting()
+	
+func throw_ice_wall():
+	var screen_width = get_viewport_rect().size.x
+	var ice_cube_width = 100
+	var y_pos = global_position.y - 100
+	for x in range(0, screen_width, ice_cube_width):
+		var ice_cube = projectile_ice_cube_scene.instantiate()
+		get_parent().add_child(ice_cube)
+		ice_cube.global_position = Vector2(x + ice_cube_width/2, y_pos)
+		ice_cube.set_as_static_wall()
+	
+func run_away():
+	var tween = create_tween()
+	tween.tween_property(self, "position:y", position.y - 300, 1.5)
+	tween.tween_callback(Callable(self, "queue_free"))
+	

--- a/scripts/ice_cube.gd
+++ b/scripts/ice_cube.gd
@@ -15,5 +15,4 @@ func _on_ball_hit(ball: Node2D):
 		if health <= 0:
 			ball.linear_velocity.y = -abs(ball.linear_velocity.y)
 			ball.linear_velocity = ball.linear_velocity * 1.5
-			
 			queue_free()

--- a/scripts/projectile_ice_cube.gd
+++ b/scripts/projectile_ice_cube.gd
@@ -1,29 +1,46 @@
 extends Area2D
 
-var velocity = Vector2.ZERO
-var canHurtBoss = false
+var velocity := Vector2.ZERO
+var canHurtBoss := false
+var is_static_wall := false
 
 func _ready():
 	connect("body_entered", Callable(self, "_on_body_entered"))
 	connect("area_entered", Callable(self, "_on_area_entered"))
 
 func _process(delta):
-	if position.y > get_viewport_rect().size.y + 100:
-		queue_free()
-	position += velocity * delta
+	if not is_static_wall:
+		position += velocity * delta
+		
+		# free if off screen
+		var viewport_rect := get_viewport_rect()
+		if not viewport_rect.has_point(global_position):
+			queue_free()
 
 func _on_body_entered(body):
 	# if the ice cube hits the player, hurt them
-	if body.is_in_group("player"):
+	if not is_static_wall and body.is_in_group("player"):
 		body.take_damage()
 		queue_free()
+		
+	if is_static_wall and body.is_in_group("player"):
+		body.take_damage()
+		body.bounce_back_from_wall(global_position)
 
 func _on_area_entered(area):
 	# if the ice cube is hit by the stick, be hit back
 	if area.is_in_group("player_stick"):
 		canHurtBoss = true
 		velocity = -velocity
+	# if the ice cube hits the boss, hurt them
 	elif area.is_in_group("boss"):
 		if canHurtBoss:
 			area.take_damage()
 			queue_free()
+	# if the ice cube is hit by the puck, break
+	elif area.is_in_group("puck"):
+		queue_free()
+
+func set_as_static_wall():
+	is_static_wall = true
+	velocity = Vector2.ZERO

--- a/scripts/puck.gd
+++ b/scripts/puck.gd
@@ -1,0 +1,10 @@
+extends Area2D
+
+var velocity := Vector2.ZERO
+
+func _ready():
+	add_to_group("puck")
+	connect("body_entered", Callable(self, "_on_body_entered"))
+
+func _process(delta):
+	position += velocity * delta

--- a/scripts/puck.gd.uid
+++ b/scripts/puck.gd.uid
@@ -1,0 +1,1 @@
+uid://bixsrfu72806w


### PR DESCRIPTION
this pr creates the ice cream boss rage phase & new launch-able pucks
- after the ice cream boss has been hit back by the ice cubes x amount of times, it rages:
  - creating an ice cube wall
  - running away
- at this point, the player can move vertically and press `shift` to launch a hockey puck with their stick
  - moving into the ice cubes hurts the player and bounces them back
  - launching hockey pucks can break the ice cubes

this pr also:
- removes manual movement of player & transitions to rely on godot's physics engine
- conducts some code clean up/organization

**click on the image below to watch the demo**:
[![watch the demo here](https://i.imgur.com/8SqD54E.png)](https://drive.google.com/file/d/1t4uwK8WROEYTmaQ3BWCcnB2ShPXUAPX8/view?usp=drive_link)
